### PR TITLE
Download dependencies before building

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -9,6 +9,15 @@ build_func() {
 
     echo
     echo "##############################"
+    echo "##### download dependencies"
+    echo "##############################"
+    go get github.com/aws/aws-lambda-go/lambda
+    go get github.com/aws/aws-sdk-go/aws
+    go get github.com/aws/aws-sdk-go/aws/session
+    echo "SUCCESS"
+
+    echo
+    echo "##############################"
     echo "##### build"
     echo "##############################"
     rm -rf $FUNC_NAME


### PR DESCRIPTION
Hi GU!
First of all, thanks for sharing this code :).

WDYT about ensuring dependencies are downloaded before calling `go build` in the build script? Build fails if they are not available... I've just tested in a fresh go environment and this change works, as follows:
```
##############################
##### download dependencies
##############################
SUCCESS

##############################
##### build
##############################
SUCCESS

##############################
##### zip
##############################
  adding: start-ec2-instances (deflated 63%)
SUCCESS

##### Time elapsed (409)

##############################
##### download dependencies
##############################
SUCCESS

##############################
##### build
##############################
SUCCESS

##############################
##### zip
##############################
  adding: stop-ec2-instances (deflated 63%)
SUCCESS

##### Time elapsed (3)
```
Best regards,